### PR TITLE
Breadcrumbs mobile issue and Issue no:17

### DIFF
--- a/IMAGE-CARD-LONG.ftl
+++ b/IMAGE-CARD-LONG.ftl
@@ -6,7 +6,7 @@
     </h2>-->
     <div class="jmimg--main--cardblock bg-light">
     	<div class="row no-gutters">
-    		<div class="col-4">
+    		<div class="col-7">
     			<div class="jmimg--cardblock--body body">
     				<h6 class="jmimg--cardblock--title">${PreTitle.getData()}</h6>
     				<h3 class="jmimg--cardblock--text">${Title.getData()}</h3>
@@ -35,7 +35,7 @@
     				</#if>
     			</div>
     		</div>
-    		<div class="col-8 jmimg--cardblock--longcol">
+    		<div class="col-5 jmimg--cardblock--longcol">
                 <#if (ImageLarge.getData())?? && ImageLarge.getData() != "">
                 	<img class="jmimg--cardblock-img rounded-0" alt="${ImageLarge.getAttribute("alt")}" data-fileentryid="${ImageLarge.getAttribute("fileEntryId")}" src="${ImageLarge.getData()}" />
                 </#if>

--- a/scss/_accordian.scss
+++ b/scss/_accordian.scss
@@ -56,7 +56,7 @@
       font-size: 14px;
     }
     .jmaccrdn__arrow {
-      @include generateIcon(20px, 20px, "../images/new__jm__images/jm__accrdn_arrow_blue.svg");
+      @include generateIcon(28px, 28px, "../images/new__jm__images/jm__accrdn_arrow_blue.svg");
       margin-left: 8px;
     }
   }

--- a/scss/_breadcrumbs.scss
+++ b/scss/_breadcrumbs.scss
@@ -9,7 +9,7 @@
     border-radius: 0;
     margin-bottom: 0;
     background: $jmDarkCharcoalColorOpc5;
-    flex-wrap: wrap;
+    flex-wrap: nowrap;
     padding: 0.75rem 78px !important;
   }
   .breadcrumb-item {

--- a/scss/_breadcrumbs.scss
+++ b/scss/_breadcrumbs.scss
@@ -9,7 +9,7 @@
     border-radius: 0;
     margin-bottom: 0;
     background: $jmDarkCharcoalColorOpc5;
-    flex-wrap: nowrap;
+    flex-wrap: wrap;
     padding: 0.75rem 78px !important;
   }
   .breadcrumb-item {

--- a/scss/_common.scss
+++ b/scss/_common.scss
@@ -241,13 +241,13 @@ a.sub-child {
 .arrow__forward {
   background: url("../images/new__jm__images/arrow_forward-white.svg") 0 0
     no-repeat transparent;
-  display: block;
   width: 24px;
   height: 24px;
   margin-left: 8px;
   top: 50%;
   margin-top: -2px;
   margin-bottom: 0!important;
+  float: right;
 }
 .top-left {
   position: absolute;

--- a/scss/_imgcardblock.scss
+++ b/scss/_imgcardblock.scss
@@ -13,7 +13,6 @@
 .jmimg-cardblock--right-img img {
   width: 100%;
   height: 100%;
-  object-fit: cover;
 }
 .image-card-block__body {
 	.journal-content-article {
@@ -76,11 +75,11 @@
   }
 }
 .jmimg--cardblock-link--icon {
-  display: block;
   width: 24px;
   margin-top: 2px;
   height: 24px;
   margin-left: 8px;
+  float: left;
 }
 .image-card-block__body{
   .journal-content-article {
@@ -241,7 +240,7 @@
     @include generateFont($jmFont, 20px, 1.2em, $jmDarkCharcoalColor, 1, 500);
   }
   .jmimg--cardblock-link--text {
-    display: none;
+    display: block;
   }
   .col-md-4.\33 {
     .jmimg-cardblock--col-img {
@@ -266,8 +265,8 @@
     display: flex;
     margin-top: 0px;
     bottom: 15px;
-    float: right;
-    margin-top: -15px;
+    float: left;
+    margin-top: 15px;
     margin-right: 5px;
     position: relative;
     @include generateFont($jmMediumFont, 17px, 22px, $jmEgyptianBlueColor);
@@ -336,7 +335,6 @@
     flex: 1 1 auto;
     min-height: 1px;
     @include generatePadding(0.7rem, 0, 0.7rem, 0.5rem);
-    width: 175%;
   }
   .jmimg-card_block {
     height: auto;

--- a/scss/_imgcardblock.scss
+++ b/scss/_imgcardblock.scss
@@ -13,6 +13,7 @@
 .jmimg-cardblock--right-img img {
   width: 100%;
   height: 100%;
+  object-fit: cover;
 }
 .image-card-block__body {
 	.journal-content-article {

--- a/scss/_imgcardblock.scss
+++ b/scss/_imgcardblock.scss
@@ -326,9 +326,9 @@
 @media (max-width: 575.98px) {
   .jmimg--cardblock--longcol {
     .jmimg--cardblock-img.rounded-0 {
-      height: 100px;
-      float: right;
-      width: 125px;
+      height: 100%;
+      width: 100%;
+      object-fit: cover;
     }
   }
   .jmimg--cardblock--body {

--- a/scss/_montage.scss
+++ b/scss/_montage.scss
@@ -10,7 +10,7 @@
     gap: 24px;
 }
 .card__container{
-    padding: 40px;
+    padding: 30px;
     background-color: $jmEgyptianBlueColor;
     margin-bottom: 24px;
     display: flex;
@@ -18,6 +18,7 @@
 }
 .montage__data{
 	margin-bottom: 30px;
+    margin-top: 30px;
     .journal-content-article{
         height: 100%;
     }


### PR DESCRIPTION
1. Breadcrumbs menus not wrapping properly into mobile screen.
2. Issue no:17 for **Card is touching to the Breadcrumb area. in Mobile view Forward-Arrow icon overlap with Image.**
3. Issue bo:26 for **Forward Icon  overlap on text in mobile screen.**
4. Fixed the only UI issue for issue no 22/ fixes for liferay developer is pending see the below image
     
![image](https://user-images.githubusercontent.com/99167608/162435138-b9b777fe-437f-4fed-ad5f-fbc74c4a8872.png)
