### PR TITLE
fixes on pages suggested by Amzed

### DIFF
--- a/scss/_common.scss
+++ b/scss/_common.scss
@@ -634,6 +634,7 @@ sub{
   bottom: -5px;
 }
 .jmgeneral--hero .general_hero__heading{
+  margin-top: 26px;
   @include generateFont($jmMediumFont, 46px, 60px, $jmDarkCharcoalColor);
 }
 .child-menu li h1 a {
@@ -656,4 +657,10 @@ sub{
   max-height: calc(100vh - 200px);
   overflow: auto;
   min-height: 300px;
+}
+
+@media (min-width: 993px) { 
+  .row.jmpanelblock__row{
+    padding: 20px;
+  }
 }

--- a/scss/_common.scss
+++ b/scss/_common.scss
@@ -633,9 +633,11 @@ sup{
 sub{
   bottom: -5px;
 }
-.jmgeneral--hero .general_hero__heading{
-  margin-top: 26px;
-  @include generateFont($jmMediumFont, 46px, 60px, $jmDarkCharcoalColor);
+.jmgeneral--hero {
+  margin-top: 35px;
+  .general_hero__heading{
+    @include generateFont($jmMediumFont, 46px, 60px, $jmDarkCharcoalColor);
+  }
 }
 .child-menu li h1 a {
   @include generateFont($jmMediumFont, 16px, 24px, $jmDarkCharcoalColor!important);
@@ -660,7 +662,7 @@ sub{
 }
 .jm-richtext__subtag {
   font-size: 18px;
-  font-family: JMSansRegular;
+  font-family: $jmFont;
 }
 
 @media (min-width: 993px) { 

--- a/scss/_common.scss
+++ b/scss/_common.scss
@@ -658,6 +658,10 @@ sub{
   overflow: auto;
   min-height: 300px;
 }
+.jm-richtext__subtag {
+  font-size: 18px;
+  font-family: JMSansRegular;
+}
 
 @media (min-width: 993px) { 
   .row.jmpanelblock__row{

--- a/scss/_imgcardblock.scss
+++ b/scss/_imgcardblock.scss
@@ -25,7 +25,7 @@
 }
 .image-card-block {
   [class^='col-md'] {
-    margin-bottom: 20px;
+    margin-bottom: 20px 0;
   }
   &.container{
     padding-left: 0;

--- a/scss/_imgcardblock.scss
+++ b/scss/_imgcardblock.scss
@@ -21,7 +21,7 @@
 	}
 }
 .image-card-block__inner {
-  margin: 20px 0px;
+  margin: 20px 20px;
 }
 .image-card-block {
   [class^='col-md'] {

--- a/scss/_imgcardblock.scss
+++ b/scss/_imgcardblock.scss
@@ -21,11 +21,11 @@
 	}
 }
 .image-card-block__inner {
-  margin: 20px 20px;
+  margin: 20px 0px;
 }
 .image-card-block {
   [class^='col-md'] {
-    margin-bottom: 20px 0;
+    margin-bottom: 20px;
   }
   &.container{
     padding-left: 0;


### PR DESCRIPTION
1. The hero title looks much closer to the breadcrumb unlike other pages.
  - **margin-top: 26px** is used to make spacing.

2. Image Panel Issue
  -provide padding to the container. with using media query for pixcel more that 993px.
  
![image](https://user-images.githubusercontent.com/99167608/162950932-1a371ef2-0f44-4ae1-a87f-42dd07e124f4.png)

  
3. The background image has to be end-to-end.
   - provide margin to left and right side to the container.
    
![image](https://user-images.githubusercontent.com/99167608/162950749-c2260c09-0a78-4203-b8ba-869078be2909.png)

4. added new class **jm-richtext__subtag** to increase the font sixe of <sub> tag